### PR TITLE
Preserve icon aspect ratios in the OSD.

### DIFF
--- a/osd.xml
+++ b/osd.xml
@@ -982,6 +982,7 @@
 
         <imagetype name="iconpath">
             <area>84,533,130,100</area>
+            <preserveaspect>true</preserveaspect>
             <mask>images/osd/masks/osd_program_icon_mask.png</mask>
             <alpha>225</alpha>
         </imagetype>
@@ -1175,6 +1176,7 @@
 
         <imagetype name="iconpath">
             <area>80,541,120,90</area>
+            <preserveaspect>true</preserveaspect>
             <mask>images/osd/masks/osd_browse_icon_mask.png</mask>
             <alpha>225</alpha>
         </imagetype>


### PR DESCRIPTION
Icons are not always a standard ratio, especially when using the HQ icons from lyngsat.  Ensure that the icon's aspect ratio is preserved in the OSD, just like it is in the EPG.
